### PR TITLE
Examples and updates for task/service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # aws-terraform-ecr
 
-This repository contains terraform modules that can be used to Elastic Container Service cluster or Elastic Container Registry repo. 
+This repository contains terraform modules that can be used to Elastic Container Service cluster or Elastic Container Registry repo.
 
 ## Module listing
 - [cluster](./modules/cluster) - A terraform module that can be used to create an IAM role and when appropriate, and IAM instance profile.  This module can create both cross account roles, and service roles.
-- [ssm_service_roles](./modules/ecr) - A terraform module to provision Elastic Container Registry repo with a repo policy that controls access and lifecycle policy for images.
+- [ecr_repo](./modules/ecr) - A terraform module to provision Elastic Container Registry repo with a repo policy that controls access and lifecycle policy for images.
+- [service_taskdef](./modules/tasks) - A terraform module to deploy the required task definitions for the ecs cluster.
+
+## Examples
+- [EC2 ECS Example](./examples/EC2/README.md)
+- [FARGATE ECS Example](./examples/FARGATE/README.md)

--- a/examples/EC2/README.md
+++ b/examples/EC2/README.md
@@ -1,0 +1,5 @@
+## Example of ECS EC2 Cluster
+
+This is an example of an ECS cluster running with the Rackspace VPC and EC2 modules.
+Its recommended to use a template file for your container definitions as its easier to update this for a customer.
+To note here, is the AMI is a dynamic lookup to the latest ECS AMI. Depending on the customers release strategy for new instance you may want to change this.

--- a/examples/EC2/ec2ecs-sample-app.json
+++ b/examples/EC2/ec2ecs-sample-app.json
@@ -1,0 +1,52 @@
+[
+  {
+    "dnsSearchDomains": null,
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${LOGS_GROUP}",
+        "awslogs-region": "${AWS_REGION}",
+        "awslogs-stream-prefix": "ecstest",
+        "awslogs-create-group": "true"
+      }
+    },
+    "entryPoint": [
+      "sh",
+      "-c"
+    ],
+    "portMappings": [
+      {
+        "hostPort": 80,
+        "protocol": "tcp",
+        "containerPort": 80
+      }
+    ],
+    "command": [
+      "/bin/sh -c \"echo '<html> <head> <title>Amazon ECS EC2 Sample App</title> <style>body {margin-top: 40px; background-color: #333;} </style> </head><body> <div style=color:white;text-align:center> <h1>Amazon ECS Sample App</h1> <h2>Congratulations!</h2> <p>Your application is now running on a container in Amazon ECS on EC2!</p> </div></body></html>' >  /usr/local/apache2/htdocs/index.html && httpd-foreground\""
+    ],
+    "linuxParameters": null,
+    "cpu": 256,
+    "memory": null,
+    "memoryReservation": 256,
+    "environment": [],
+    "ulimits": null,
+    "dnsServers": null,
+    "mountPoints": [],
+    "workingDirectory": null,
+    "dockerSecurityOptions": null,
+    "memory": null,
+    "volumesFrom": [],
+    "image": "httpd:2.4",
+    "disableNetworking": null,
+    "healthCheck": null,
+    "essential": true,
+    "links": [],
+    "hostname": null,
+    "extraHosts": null,
+    "user": null,
+    "readonlyRootFilesystem": null,
+    "dockerLabels": null,
+    "privileged": null,
+    "name": "ecs-ec2-sample-app"
+  }
+]

--- a/examples/EC2/main.tf
+++ b/examples/EC2/main.tf
@@ -1,0 +1,216 @@
+provider "aws" {
+  version    = "~> 1.2"
+  access_key = "${var.aws_access_key}"
+  secret_key = "${var.aws_secret_key}"
+  region     = "${var.aws_region}"
+}
+
+module "vpc" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.2"
+
+  vpc_name = "ECS-EC2-Example-VPC"
+}
+
+resource "aws_security_group" "allow_web" {
+  name        = "allow_web"
+  description = "Allow inbound web traffic"
+  vpc_id      = "${module.vpc.vpc_id}"
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+module "ecs_cluster" {
+  source           = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ecs/modules/cluster//?ref=v0.0.2"
+  ecs_cluster_name = "${var.ecs_cluster_name}"
+}
+
+data "aws_region" "current_region" {}
+data "aws_caller_identity" "current" {}
+
+data "template_file" "ec2ecs-sample-app" {
+  template = "${file("ec2ecs-sample-app.json")}"
+
+  vars {
+    AWS_REGION = "${var.aws_region}"
+    LOGS_GROUP = "${aws_cloudwatch_log_group.ec2ecs-sample-app.name}"
+  }
+}
+
+resource "aws_iam_role" "ecs_role_task_assume" {
+  name = "ecsec2_task_assume"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "ecs_task_assume_policy" {
+  name = "ecsec2_task_assume_policy"
+  role = "${aws_iam_role.ecs_role_task_assume.id}"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ecr:GetAuthorizationToken",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_cloudwatch_log_group" "ec2ecs-sample-app" {
+  name              = "/ecs/ec2ecs-sample-app"
+  retention_in_days = 30
+
+  tags {
+    Name = "ec2ecs-sample-app"
+  }
+}
+
+resource "random_string" "password" {
+  length      = 16
+  special     = false
+  min_upper   = 1
+  min_lower   = 1
+  min_numeric = 1
+}
+
+resource "random_string" "sqs_rstring" {
+  length  = 18
+  upper   = false
+  special = false
+}
+
+resource "aws_sqs_queue" "ec2-asg-test_sqs" {
+  name = "${random_string.sqs_rstring.result}-my-example-queue"
+}
+
+module "sns_sqs" {
+  source     = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns?ref=v0.0.2"
+  topic_name = "${random_string.sqs_rstring.result}-ec2-asg-test-topic"
+
+  create_subscription_1 = true
+  protocol_1            = "sqs"
+  endpoint_1            = "${aws_sqs_queue.ec2-asg-test_sqs.arn}"
+}
+
+data "aws_ami" "amazon_ecs" {
+  most_recent = true
+  owners      = ["591542846629"]
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-2018.03.*-amazon-ecs-optimized"]
+  }
+}
+
+module "ec2_asg" {
+  source    = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=v0.0.5"
+  ec2_os    = "amazon"
+  asg_count = "1"
+
+  load_balancer_names = [""]
+  cw_low_operator     = "LessThanThreshold"
+
+  instance_role_managed_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonEC2FullAccess",
+    "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role",
+    "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access",
+  ]
+
+  instance_role_managed_policy_arn_count = "3"
+  environment                            = "${var.environment}"
+  ssm_association_refresh_rate           = "rate(1 day)"
+  cw_scaling_metric                      = "CPUUtilization"
+  enable_ebs_optimization                = "False"
+  scaling_min                            = "1"
+  cloudwatch_log_retention               = "30"
+  cw_high_period                         = "60"
+  enable_scaling_notification            = true
+  subnets                                = ["${element(module.vpc.public_subnets, 0)}", "${element(module.vpc.public_subnets, 1)}"]
+  ec2_scale_down_adjustment              = "1"
+  image_id                               = "${data.aws_ami.amazon_ecs.image_id}"
+  cw_low_period                          = "300"
+  key_pair                               = "${var.ec2_keypair}"
+  tenancy                                = "default"
+  backup_tag_value                       = "False"
+  ec2_scale_down_cool_down               = "60"
+  instance_type                          = "t2.small"
+
+  # If ALB target groups are being used, one can specify ARNs like the commented line below.
+  #target_group_arns                      = ["${aws_lb_target_group.my_tg.arn}"]
+
+  ec2_scale_up_adjustment       = "1"
+  cw_high_threshold             = "60"
+  scaling_notification_topic    = "${module.sns_sqs.topic_arn}"
+  cw_low_threshold              = "30"
+  resource_name                 = "ECS-Cluster-ASG"
+  ec2_scale_up_cool_down        = "60"
+  ssm_patching_group            = "MyPatchGroup1"
+  health_check_grace_period     = "300"
+  security_group_list           = ["${module.vpc.default_sg}", "${aws_security_group.allow_web.id}"]
+  perform_ssm_inventory_tag     = "True"
+  terminated_instances          = "30"
+  health_check_type             = "EC2"
+  cw_low_evaluations            = "3"
+  cw_high_evaluations           = "3"
+  primary_ebs_volume_iops       = "0"
+  detailed_monitoring           = "True"
+  primary_ebs_volume_type       = "gp2"
+  primary_ebs_volume_size       = "20"
+  scaling_max                   = "2"
+  cw_high_operator              = "GreaterThanThreshold"
+  install_codedeploy_agent      = "False"
+  asg_wait_for_capacity_timeout = "10m"
+  initial_userdata_commands     = "${module.ecs_cluster.cluster_join_command}"
+}
+
+resource "aws_ecs_task_definition" "ecs_task_def" {
+  family                   = "${lower(var.task_name)}"
+  container_definitions    = "${data.template_file.ec2ecs-sample-app.rendered}"
+  network_mode             = "${var.network_mode}"
+  execution_role_arn       = "${aws_iam_role.ecs_role_task_assume.arn}"
+  requires_compatibilities = ["EC2"]
+}
+
+resource "aws_ecs_service" "ecs_service_def" {
+  name            = "${lower(var.service_name)}"
+  cluster         = "${module.ecs_cluster.cluster_id}"
+  task_definition = "${aws_ecs_task_definition.ecs_task_def.arn}"
+  desired_count   = "${var.ecs_service_desired_count}"
+}

--- a/examples/EC2/variables.tf
+++ b/examples/EC2/variables.tf
@@ -1,0 +1,43 @@
+variable "aws_region" {
+  description = "AWS REGION"
+  default     = "us-east-2"
+}
+
+variable "aws_access_key" {
+  description = "AWS Access Key stored in secrets"
+}
+
+variable "aws_secret_key" {
+  description = "AWS Secret Key stored in secrets"
+}
+
+variable "environment" {
+  description = "The environment we are building for"
+  default     = "Test"
+}
+
+variable "ecs_cluster_name" {
+  description = "The environment we are building for"
+  default     = "ECS_EC2_Cluster_Example"
+}
+
+variable "ec2_keypair" {
+  description = "SSH keypair in the region to be built for the EC2 Instances"
+  default     = "my_ec2_keypair"
+}
+
+variable "task_name" {
+  default = "ec2ecs_test_task"
+}
+
+variable "service_name" {
+  default = "ec2ecs_test_service"
+}
+
+variable "network_mode" {
+  default = "bridge"
+}
+
+variable "ecs_service_desired_count" {
+  default = "1"
+}

--- a/examples/FARGATE/README.md
+++ b/examples/FARGATE/README.md
@@ -1,0 +1,4 @@
+## Example of ECS Fargate Cluster
+
+This is an example of an ECS cluster running with the Rackspace VPC.
+Its recommended to use a template file for your container definitions as its easier to update this for a customer.

--- a/examples/FARGATE/fargate-sample-app.json
+++ b/examples/FARGATE/fargate-sample-app.json
@@ -1,0 +1,53 @@
+[
+  {
+    "dnsSearchDomains": null,
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${LOGS_GROUP}",
+        "awslogs-region": "${AWS_REGION}",
+        "awslogs-stream-prefix": "ecs"
+      }
+    },
+    "entryPoint": [
+      "sh",
+      "-c"
+    ],
+    "portMappings": [
+      {
+        "hostPort": 80,
+        "protocol": "tcp",
+        "containerPort": 80
+      },
+      {
+        "hostPort": 22,
+        "protocol": "tcp",
+        "containerPort": 22
+      }
+    ],
+    "command": [
+      "/bin/sh -c \"echo '<html> <head> <title>Amazon ECS Sample App</title> <style>body {margin-top: 40px; background-color: #333;} </style> </head><body> <div style=color:white;text-align:center> <h1>Amazon ECS Sample App</h1> <h2>Congratulations!</h2> <p>Your application is now running on a container in Amazon ECS Fargate!</p> </div></body></html>' >  /usr/local/apache2/htdocs/index.html && httpd-foreground\""
+    ],
+    "linuxParameters": null,
+    "environment": [],
+    "ulimits": null,
+    "dnsServers": null,
+    "mountPoints": [],
+    "workingDirectory": null,
+    "dockerSecurityOptions": null,
+    "memory": null,
+    "volumesFrom": [],
+    "image": "httpd:2.4",
+    "disableNetworking": null,
+    "healthCheck": null,
+    "essential": true,
+    "links": [],
+    "hostname": null,
+    "extraHosts": null,
+    "user": null,
+    "readonlyRootFilesystem": null,
+    "dockerLabels": null,
+    "privileged": null,
+    "name": "fargate-sample-app"
+  }
+]

--- a/examples/FARGATE/main.tf
+++ b/examples/FARGATE/main.tf
@@ -1,0 +1,134 @@
+provider "aws" {
+  version    = "~> 1.2"
+  access_key = "${var.aws_access_key}"
+  secret_key = "${var.aws_secret_key}"
+  region     = "${var.aws_region}"
+}
+
+module "vpc" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.2"
+
+  vpc_name = "ECS-FARGATE-Example-VPC"
+}
+
+resource "aws_security_group" "allow_web" {
+  name        = "allow_web"
+  description = "Allow inbound web traffic"
+  vpc_id      = "${module.vpc.vpc_id}"
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+module "ecs_cluster" {
+  source           = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ecs/modules/cluster//?ref=v0.0.2"
+  ecs_cluster_name = "${var.ecs_cluster_name}"
+}
+
+resource "aws_iam_role" "ecs_role_task_assume" {
+  name = "ecsfargate_task_assume"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "ecs_task_assume_policy" {
+  name = "ecsfargate_task_assume_policy"
+  role = "${aws_iam_role.ecs_role_task_assume.id}"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ecr:GetAuthorizationToken",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+data "aws_region" "current_region" {}
+data "aws_caller_identity" "current" {}
+
+data "template_file" "fargate-sample-app" {
+  template = "${file("fargate-sample-app.json")}"
+
+  vars {
+    AWS_REGION = "${var.aws_region}"
+    LOGS_GROUP = "${aws_cloudwatch_log_group.fargate-sample-app.name}"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "fargate-sample-app" {
+  name              = "/ecs/fargate-sample-app"
+  retention_in_days = 30
+
+  tags {
+    Name = "fargate-sample-app"
+  }
+}
+
+resource "aws_ecs_task_definition" "ecs_task_def" {
+  family                   = "${lower(var.task_name)}"
+  container_definitions    = "${data.template_file.fargate-sample-app.rendered}"
+  execution_role_arn       = "${aws_iam_role.ecs_role_task_assume.arn}"
+  network_mode             = "${var.network_mode}"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "${var.task_cpu}"
+  memory                   = "${var.task_memory}"
+}
+
+resource "aws_ecs_service" "ecs_service_def" {
+  name            = "${lower(var.service_name)}"
+  cluster         = "${module.ecs_cluster.cluster_id}"
+  task_definition = "${aws_ecs_task_definition.ecs_task_def.arn}"
+  desired_count   = "${var.ecs_service_desired_count}"
+  launch_type     = "FARGATE"
+
+  network_configuration = {
+    subnets          = ["${element(module.vpc.public_subnets, 0)}", "${element(module.vpc.public_subnets, 1)}"]
+    security_groups  = ["${aws_security_group.allow_web.id}"]
+    assign_public_ip = "true"
+  }
+}

--- a/examples/FARGATE/variables.tf
+++ b/examples/FARGATE/variables.tf
@@ -1,0 +1,46 @@
+variable "aws_region" {
+  description = "AWS REGION"
+  default     = "us-east-2"
+}
+
+variable "aws_access_key" {
+  description = "AWS Access Key stored in secrets"
+}
+
+variable "aws_secret_key" {
+  description = "AWS Secret Key stored in secrets"
+}
+
+variable "environment" {
+  description = "The environment we are building for"
+  default     = "Test"
+}
+
+variable "ecs_cluster_name" {
+  description = "The environment we are building for"
+  default     = "ECS_FARGATE_Cluster_Example"
+}
+
+variable "task_name" {
+  default = "ecs_fargate_test_task"
+}
+
+variable "service_name" {
+  default = "ecs_fargate_test_service"
+}
+
+variable "network_mode" {
+  default = "awsvpc"
+}
+
+variable "ecs_service_desired_count" {
+  default = "1"
+}
+
+variable "task_cpu" {
+  default = "256"
+}
+
+variable "task_memory" {
+  default = "512"
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,4 @@
+# Examples
+
+[EC2](./EC2/README.md) Is an example of a full ECS cluster with the Rackspace terraform modules including
+[Fargate](./FARGATE/README.md) Is an example of a full ECS cluster built upon the Fargate platform.

--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -1,0 +1,13 @@
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| ecs_cluster_name | A name for the cluster | string | `` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| cluster_arn | The ARN of the cluster |
+| cluster_id | The ID of the cluster |
+| cluster_join_command | The join command to join the cluster, to run on the EC2 Host Instance. |

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -1,3 +1,3 @@
 resource "aws_ecs_cluster" "ecs-cluster" {
-  name = "${var.cluster_name}"
+  name = "${var.ecs_cluster_name}"
 }

--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -7,3 +7,17 @@ output "cluster_arn" {
   description = "The ARN of the cluster"
   value       = "${aws_ecs_cluster.ecs-cluster.arn}"
 }
+
+output "cluster_join_command" {
+  description = "The join command to join the cluster, to run on the EC2 Host Instance."
+
+  value = <<EOF
+echo ECS_CLUSTER=${var.ecs_cluster_name} >> /etc/ecs/ecs.config
+echo ECS_DATADIR=/data >> /etc/ecs/ecs.config
+echo ECS_ENABLE_TASK_IAM_ROLE=true >> /etc/ecs/ecs.config
+echo ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true >> /etc/ecs/ecs.config
+echo ECS_LOGFILE=/log/ecs-agent.log >> /etc/ecs/ecs.config
+echo ECS_AVAILABLE_LOGGING_DRIVERS='["json-file","awslogs"]' >> /etc/ecs/ecs.config
+echo ECS_LOGLEVEL=info >> /etc/ecs/ecs.config
+EOF
+}

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -1,4 +1,4 @@
-variable "cluster_name" {
+variable "ecs_cluster_name" {
   description = "A name for the cluster"
   type        = "string"
   default     = ""

--- a/modules/service_taskdef/README.md
+++ b/modules/service_taskdef/README.md
@@ -1,0 +1,16 @@
+# Service and Task Defintions
+Note: This is not a module and will not be being that service and task definitions are different for every application on ECS. This folder is however a guide on how to get started with ECS Service and Task Definitions.
+
+## Odd Quirks
+Note that there is an odd behavior when a new task is created, the old version is deregistered and not available to be used again. You are _NOT_ able to revert to the old version. This is very dissimilar to lambdas. [link](https://github.com/terraform-providers/terraform-provider-aws/issues/258) As you change/update the current task definition in terraform, the default behavior is to create a new task definition version if you are using the same name. As soon as it is created the old one is deregistered. If you need to roll back to a setup the same as the old definition, make sure you update to a new name to roll forward, as rolling backward is unsupported in terraform.
+
+## Fargate Note on task definitions
+- Be sure to use FARGATE launch type
+- With Fargate you MUST use awsVPC
+- Fargate requires you specify the size of each task.
+
+
+## Helpful links
+- [Task Definition Parameters](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html)
+- [Fargate Task Definitions](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-task-defs)
+- [Fargate Tasks and Services](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-tasks-services)

--- a/modules/service_taskdef/examples/main.tf
+++ b/modules/service_taskdef/examples/main.tf
@@ -1,0 +1,13 @@
+resource "aws_ecs_task_definition" "ecs_task_def" {
+  family                = "${lower(var.task_name)}"
+  container_definitions = "${var.container_definition}"
+  execution_role_arn    = "${format("arn:aws:iam::%s:role/ecsTaskExecutionRole", data.aws_caller_identity.current.account_id)}"
+  network_mode          = "${var.network_mode}"
+}
+
+resource "aws_ecs_service" "ecs_service_def" {
+  name            = "${lower(var.service_name)}"
+  cluster         = "${aws_ecs_cluster.cluster.id}"
+  task_definition = "${aws_ecs_task_definition.ecs_task_def.arn}"
+  desired_count   = "${var.ecs_service_desired_count}"
+}

--- a/tests/cluster/main.tf
+++ b/tests/cluster/main.tf
@@ -6,5 +6,5 @@ provider "aws" {
 module "ecs" {
   source = "../../module/modules/cluster"
 
-  cluster_name = "MyCluster"
+  ecs_cluster_name = "MyCluster"
 }


### PR DESCRIPTION
adds examples on how to builds ECS EC2 and Fargate with rackspace modules. Shows how to use task definitions and services, as well as mentions a few quirks.