### PR TITLE
Update module source refs to SSH

### DIFF
--- a/modules/cluster/examples/ecs.tf
+++ b/modules/cluster/examples/ecs.tf
@@ -10,7 +10,7 @@ resource "random_string" "ecs_rstring" {
 }
 
 module "ecs" {
-  source = "github.com/rackspace-infrastructure-automation/aws-terraform-ecs//?ref=v0.0.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ecs//?ref=v0.0.1"
 
   cluster_name = "MyCluster"
 }

--- a/modules/ecr/README.md
+++ b/modules/ecr/README.md
@@ -1,7 +1,7 @@
 ## Basic Usage
 ```
 module "ecr_repo" {
-  source              = "github.com/rackspace-infrastructure-automation/aws-terraform-ecs/modules/ecr?ref=v0.0.1"
+  source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ecs/modules/ecr?ref=v0.0.1"
   provision_ecr       = true
   ecr_repository_name = "myrepo-${random_string.ecs_rstring.result}"
 
@@ -73,5 +73,3 @@ EOF
 | ecr_repository_name | Name of the ECR repository |
 | ecr_repository_registry_id | Name of the ECR repository |
 | ecr_repository_registry_url | URL of the ECR repository |
-
-

--- a/modules/ecr/examples/main.tf
+++ b/modules/ecr/examples/main.tf
@@ -10,7 +10,7 @@ resource "random_string" "ecs_rstring" {
 }
 
 module "ecr_repo" {
-  source              = "github.com/rackspace-infrastructure-automation/aws-terraform-ecs/modules/ecr?ref=v0.0.1"
+  source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ecs/modules/ecr?ref=v0.0.1"
   provision_ecr       = true
   ecr_repository_name = "myrepo-${random_string.ecs_rstring.result}"
 


### PR DESCRIPTION
Updates all module source references using HTTP syntax to the SSH syntax.

related issue: rackspace-infrastructure-automation/aws-terraform-internal#155